### PR TITLE
Changed getMimeType to mimeType

### DIFF
--- a/src/Http/Services/GetFiles.php
+++ b/src/Http/Services/GetFiles.php
@@ -232,7 +232,7 @@ trait GetFiles
             return 'dir';
         }
 
-        $mime = $this->storage->getMimetype($file['path']);
+        $mime = $this->storage->mimeType($file['path']);
         $extension = $file['extension'];
 
         if (Str::contains($mime, 'directory')) {
@@ -311,7 +311,7 @@ trait GetFiles
             return false;
         }
 
-        $mime = $this->storage->getMimetype($file['path']);
+        $mime = $this->storage->mimeType($file['path']);
         $extension = $file['extension'];
 
         if (Str::contains($mime, 'directory')) {

--- a/src/Http/Services/NormalizeFile.php
+++ b/src/Http/Services/NormalizeFile.php
@@ -66,12 +66,12 @@ class NormalizeFile
      */
     private function setExtras(Collection $data)
     {
-        $mime = $this->storage->getMimetype($this->storagePath);
+        $mime = $this->storage->mimeType($this->storagePath);
 
         // Image
         if (Str::contains($mime, 'image') || $data['ext'] == 'svg') {
             $data->put('type', 'image');
-            $data->put('dimensions', $this->getDimensions($this->storage->getMimetype($this->storagePath)));
+            $data->put('dimensions', $this->getDimensions($this->storage->mimeType($this->storagePath)));
         }
 
         // Video
@@ -199,7 +199,7 @@ class NormalizeFile
 
         //If no type
 
-        return $this->storage->getMimetype($this->storagePath);
+        return $this->storage->mimeType($this->storagePath);
     }
 
     private function availablesTextExtensions()


### PR DESCRIPTION
After upgrading `league/flysystem-aws-s3-v3` to `^3.0` this error occured:

`Call to undefined method League\Flysystem\Filesystem::getMimetype()`

The package needed to be updated when upgrading Laravel from 8 to 9.